### PR TITLE
Fix foundry install target missing commit pin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+FOUNDRY_COMMIT ?= 3b1129b5bc43ba22a9bcf4e4323c5a9df0023140
+
 PROJECT_DIR = $(network)/$(shell date +'%Y-%m-%d')-$(task)
 GAS_INCREASE_DIR = $(network)/$(shell date +'%Y-%m-%d')-increase-gas-limit
 FAULT_PROOF_UPGRADE_DIR = $(network)/$(shell date +'%Y-%m-%d')-upgrade-fault-proofs


### PR DESCRIPTION
## Summary
- default the `FOUNDRY_COMMIT` used by `make install-foundry` to the pinned revision referenced in the README

## Testing
- make -n install-foundry

------
https://chatgpt.com/codex/tasks/task_e_68e55cb4b530832e806bbba3da34e8ee